### PR TITLE
Smartcontract SDK

### DIFF
--- a/contracts/DMTPMessages.sol
+++ b/contracts/DMTPMessages.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
+import "./interfaces/IDMTPMessages.sol";
 
-contract DMTPMessages{
+contract DMTPMessages is IDMTPMessages{
   mapping(address => mapping(address => bool)) delegators;
 
   event DelgetorSet(address indexed wallet, address indexed delegator);

--- a/contracts/DMTPMessages.sol
+++ b/contracts/DMTPMessages.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+contract DMTPMessages{
+  mapping(address => mapping(address => bool)) delegators;
+
+  event DelgetorSet(address indexed wallet, address indexed delegator);
+  event DelgetorDelete(address indexed wallet, address indexed delegator);
+  event MessageSent(address indexed from, address indexed to, bytes message);
+
+  function setDelegator(address _delegator) external{
+    delegators[msg.sender][_delegator] = true;
+    emit DelgetorSet(msg.sender, _delegator);
+  }
+
+  function deleteDelegator(address _delegator) external {
+    delegators[msg.sender][_delegator] = false;
+    emit DelgetorDelete(msg.sender, _delegator);
+  }
+
+  function isDelegator(address _owner, address _delegator) public view returns(bool) {
+    return delegators[_owner][_delegator];
+  }
+
+  function sendMessages(address _from, address _to, string memory _message) external {
+    require(delegators[_from][msg.sender] == true || msg.sender == _from, "DMTPMessages : Invalid delegators");
+    bytes memory data = abi.encodePacked(_message);
+    emit MessageSent(msg.sender, _to, data);
+  }
+}

--- a/contracts/interfaces/IDMTPMessages.sol
+++ b/contracts/interfaces/IDMTPMessages.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
-import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 
 interface IDMTPMessages {
     function sendMessages(address _from, address _to, string memory _message) external;

--- a/contracts/interfaces/IDMTPMessages.sol
+++ b/contracts/interfaces/IDMTPMessages.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
+
+interface IDMTPMessages {
+    function sendMessages(address _from, address _to, string memory _message) external;
+    function setDelegator(address _delegator) external;
+    function deleteDelegator(address _delegator) external;
+}


### PR DESCRIPTION
This is a smart contract for SDK that sends messages or notifications from the smart contract.
- Any users can integrate this smart contract into their smart contract and send messages or notifications.
- Before sending messages, user have to set delegator in this contract
- delegator address will be the contract address of Dapps.

Next, we have to develop backend function that monitors `MessageSent` event and send that messsages from `_from` to `_to`
- Our server monitors every `MessageSent` event emitted by each DMTPMessages contract of each chain
- The messages don't need to be decrypted because all data via smart contract are public
- So, we store law data in our DB and IPFS
